### PR TITLE
20mm grenade adjustments

### DIFF
--- a/zscript/HDBulletLib/Ammunition/20mm Grenades.zsc
+++ b/zscript/HDBulletLib/Ammunition/20mm Grenades.zsc
@@ -98,7 +98,7 @@ class WAN_20mmGrenade:SlowProjectile{
 			A_HDBlast(
 				//blastradius:128,blastdamage:random(24,48),fullblastradius:48,
 				pushradius:128,pushamount:64,fullpushradius:48,
-				fragradius:HDCONST_ONEMETRE*(1.6+0.2*stamina),fragtype:"WAN_20mmFragment",
+				fragradius:HDCONST_ONEMETRE*(3.2+0.2*stamina),fragtype:"WAN_20mmFragment",fragments:1117,
 				immolateradius:48,immolateamount:random(3,30),
 				immolatechance:10
 			);


### PR DESCRIPTION
Doubles the shrapnel radius but halves the fragment count. Changing the fragment count wasn't originally possible when these were made so they had the full payload of a 40mm grenade on direct impact but were almost harmless outside of that. This change makes them perform a bit more consistently and sensibly. They're still super strong on a direct hit, just not 40mm strong, and if one lands near an enemy and not on it it'll still do some damage.