### PR TITLE
Minor Refactoring

### DIFF
--- a/zscript/HDBulletLib/Ammunition/45ACP.zsc
+++ b/zscript/HDBulletLib/Ammunition/45ACP.zsc
@@ -2,6 +2,10 @@
 // CREATED BY POPGUY12
 // ------------------------------
 
+
+const ENC_45ACPLOADED = 0.55;
+const ENC_45ACP = ENC_45ACPLOADED * 1.35;
+
 class HDB_45ACP : HDBulletActor
 {
 	Default
@@ -43,8 +47,8 @@ class HD45ACPAmmo : HDRoundAmmo
 		SplitPickupBoxableRound(10, 50, "HD45ACPBoxPickup", "45TNA0", "45RNA0");
 	}
 
-	const EncRoundLoaded = 0.55;
-	const EncRound = EncRoundLoaded * 1.35;
+	const EncRoundLoaded = ENC_45ACPLOADED;
+	const EncRound = ENC_45ACP;
 
 	Default
 	{

--- a/zscript/HDBulletLib/SpawnHandler.zsc
+++ b/zscript/HDBulletLib/SpawnHandler.zsc
@@ -274,7 +274,7 @@ class HDBulletLibAmmoSpawner: EventHandler {
         addAmmo('HD50OMGBoxPickup', spawns_50omgbox, hdb_50omg_persistent_spawning);
         // .50 OMG Casing
         Array<HDBLRSpawnAmmoEntry> spawns_50omgcasing;
-        spawns_50omgcasing.push(addAmmoEntry('SevenMilBrass', hdb_50omg_casing_spawn_bias));
+        spawns_50omgcasing.push(addAmmoEntry('HDCasingBits', hdb_50omg_casing_spawn_bias));
         addAmmo('HDSpent50OMG', spawns_50omgcasing, hdb_50omg_persistent_spawning);
 
         // .45 ACP Box Pickup
@@ -435,7 +435,7 @@ class HDBulletLibAmmoSpawner: EventHandler {
         addAmmo('HD3006BoxPickup', spawns_3006box, hdb_3006_persistent_spawning);
         // .30-06 Casing/Brass
         Array<HDBLRSpawnAmmoEntry> spawns_3006casing;
-        spawns_3006casing.push(addAmmoEntry('SevenMilBrass', hdb_3006_casing_spawn_bias));
+        spawns_3006casing.push(addAmmoEntry('HDCasingBits', hdb_3006_casing_spawn_bias));
         addAmmo('HDSpent3006', spawns_3006casing, hdb_3006_persistent_spawning);
 
         // 4-Gauge Buckshot Box
@@ -486,7 +486,7 @@ class HDBulletLibAmmoSpawner: EventHandler {
         addAmmo('Savage300Ammo', spawns_300savageammo, hdb_300savage_persistent_spawning);
         // .300 Savage Casing
         Array<HDBLRSpawnAmmoEntry> spawns_300savage_casing;
-        spawns_300savage_casing.push(addAmmoEntry('SevenMilBrass', hdb_300savage_casing_spawn_bias));
+        spawns_300savage_casing.push(addAmmoEntry('HDCasingBits', hdb_300savage_casing_spawn_bias));
         addAmmo('Savage300Brass', spawns_300savage_casing, hdb_300savage_persistent_spawning);
 
         // 7.62 Tokarev Box Pickup


### PR DESCRIPTION
Hoists a few constants up into the static/global scope for consistency.  The local class properties should be considered deprecated.

Change various rifle casings to only spawn on HDCasingBits instead of specifically SevenMilBrass to prevent persistent replacements from causing issues when dropping casings